### PR TITLE
feat: Implementar permisos, grabación y manejo web

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,10 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.

--- a/lib/widgets/audio_input_handler.dart
+++ b/lib/widgets/audio_input_handler.dart
@@ -1,9 +1,64 @@
 import 'package:flutter/material.dart';
 import 'package:geiger_calc/state/app_state.dart';
 import 'package:provider/provider.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart' show kIsWeb;
 
 class AudioInputHandler extends StatelessWidget {
   const AudioInputHandler({super.key});
+
+  Future<void> _handleRecordAudio(BuildContext context, AppState appState) async {
+    if (kIsWeb) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Audio recording is not available on the Web platform.'),
+        ),
+      );
+      return;
+    }
+
+    if (Platform.isAndroid || Platform.isIOS) {
+      var status = await Permission.microphone.request();
+      if (status.isGranted) {
+        appState.startRecording();
+      } else if (status.isPermanentlyDenied) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('Microphone permission is permanently denied. Please enable it in app settings.'),
+              action: SnackBarAction(
+                label: 'Settings',
+                onPressed: () {
+                  openAppSettings();
+                },
+              ),
+            ),
+          );
+        }
+      } else {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Microphone permission is required to record audio.'),
+            ),
+          );
+        }
+      }
+    } else {
+      // For other non-mobile, non-web platforms (e.g. desktop), attempt recording.
+      // Desktop platforms might need specific permission handling not covered here.
+      print("Attempting to record on non-mobile, non-web platform.");
+      appState.startRecording();
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    String twoDigits(int n) => n.toString().padLeft(2, '0');
+    final minutes = twoDigits(duration.inMinutes.remainder(60));
+    final seconds = twoDigits(duration.inSeconds.remainder(60));
+    return '$minutes:$seconds';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,17 +68,19 @@ class AudioInputHandler extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
             ElevatedButton.icon(
-              onPressed: appState.isLoading
-                  ? null
-                  : () {
-                      if (appState.isRecording) {
-                        appState.stopRecording();
-                      } else {
-                        appState.startRecording();
-                      }
-                    },
+              onPressed: kIsWeb
+                  ? null // Disabled on web
+                  : appState.isRecording
+                      ? () => appState.stopRecording() // Allow stopping if recording
+                      : appState.isLoading
+                          ? null // Disabled if loading (and not recording)
+                          : () => _handleRecordAudio(context, appState), // Allow starting if not loading/recording
               icon: appState.isRecording ? const Icon(Icons.stop) : const Icon(Icons.mic),
-              label: Text(appState.isRecording ? 'Stop Recording' : 'Record Audio'),
+              label: Text(kIsWeb
+                  ? 'Record (Not on Web)'
+                  : appState.isRecording
+                      ? 'Stop Recording (${_formatDuration(appState.recordingDuration)})'
+                      : 'Record Audio'),
             ),
             ElevatedButton.icon(
               onPressed: appState.isLoading ? null : appState.loadAudioAndAnalyze,

--- a/plan_de_desarrollo.md
+++ b/plan_de_desarrollo.md
@@ -35,14 +35,14 @@ Para marcar una tarea como completada, reemplace `[ ]` por `[x]`.
 
 ### Fase 5: Funcionalidades de Plataforma y Pulido
 - [x] **Carga de Archivos:** Implementar la lógica con `file_picker`.
-- [ ] **Manejo de Permisos (Android):** Integrar `permission_handler`.
-- [ ] **Grabación de Audio:** Implementar la lógica con `flutter_sound`.
-- [ ] **Manejo de Plataforma Web:** Deshabilitar la grabación de audio de forma controlada.
+- [x] **Manejo de Permisos (Android):** Integrar `permission_handler`.
+- [x] **Grabación de Audio:** Implementar la lógica con `flutter_sound`. (Nota: Se usó `record` y se mejoró)
+- [x] **Manejo de Plataforma Web:** Deshabilitar la grabación de audio de forma controlada.
 - [x] **Decodificación de Audio Real:** Implementar la decodificación de archivos de audio (ej. WAV y MP3) en `AppState` o un nuevo servicio, incluyendo conversión a mono.
 - [x] **Mejorar Visualizador de Audio:** Añadir ejes y etiquetas al gráfico de audio.
 - [x] **Extender Panel de Resultados:** Mostrar tiempo total, amplitud máxima, amplitud promedio y mínima distancia entre picos.
 - [x] **Ajustar `AnalysisParams` y `AudioAnalysisService`:** Para soportar los nuevos indicadores y valores por defecto.
-- [ ] **Manejo de Permisos (Android):** Integrar `permission_handler`.
-- [ ] **Grabación de Audio:** Implementar la lógica con `flutter_sound`.
-- [ ] **Manejo de Plataforma Web:** Deshabilitar la grabación de audio de forma controlada.
+- [x] **Manejo de Permisos (Android):** Integrar `permission_handler`.
+- [x] **Grabación de Audio:** Implementar la lógica con `flutter_sound`. (Nota: Se usó `record` y se mejoró)
+- [x] **Manejo de Plataforma Web:** Deshabilitar la grabación de audio de forma controlada.
 


### PR DESCRIPTION
Implementa las siguientes funcionalidades restantes de la Fase 5:

- Manejo de Permisos (Android):
  - Agregado permiso RECORD_AUDIO y READ_EXTERNAL_STORAGE a AndroidManifest.xml.
  - Integrado permission_handler en AudioInputHandler para solicitar permiso de micrófono antes de grabar.
  - Muestra mensajes a ti según el estado del permiso.

- Grabación de Audio:
  - Mejorada la funcionalidad de grabación existente (usando el paquete `record`).
  - Añadida visualización del tiempo de grabación transcurrido en la UI.
  - Lógica de inicio/parada de grabación y manejo de timer en AppState.

- Manejo Específico para Plataforma Web:
  - Deshabilitado el botón de grabación de audio en la plataforma web.
  - Actualizada la etiqueta del botón para informarte.
  - Prevenida la ejecución de la lógica de grabación si se ejecuta en web.

- Corrección:
  - Ajustada la lógica de habilitación/deshabilitación del botón de grabación/detención en AudioInputHandler para manejar correctamente el estado `isLoading` de la aplicación.

Actualizado plan_de_desarrollo.md para reflejar estas tareas completadas.